### PR TITLE
Add vm.max_map_count

### DIFF
--- a/elastic_stack/elasticsearch/elasticsearch-sts.yaml
+++ b/elastic_stack/elasticsearch/elasticsearch-sts.yaml
@@ -42,6 +42,14 @@ spec:
           volumeMounts:
             - name: wazuh-elasticsearch
               mountPath: /usr/share/elasticsearch/data
+        - name: increase-the-vm-max-map-count
+          image: busybox
+          command:
+            - sysctl
+            - -w
+            - vm.max_map_count=262144
+          securityContext:
+            privileged: true    
       containers:
         - name: wazuh-elasticsearch
           image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.0'


### PR DESCRIPTION
This PR solves the issue: #4 

We have added the option to increase the value of vm.max_map_count because we would have to do it manually in the Kubernetes node where the pod falls if we want the Elasticsearch container to work.

Regards,

Alfonso Ruiz-Bravo