### PR TITLE
Update wazuh images to 3.7.2 6.5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,55 @@ Deploy a Wazuh cluster with a basic Elastic stack on Kubernetes .
 
 The *instructions.md* file describes how to deploy Wazuh on Kubernetes.
 
+## Directory structure
+
+    ├── wazuh-kubernetes
+    │ ├── base
+    │ │ ├── aws-gp2-storage-class.yaml
+    │ │ ├── wazuh-ns.yaml
+    │
+    │ ├── elastic_stack
+    │ │ ├── elasticsearch
+    │ │ │ ├── cluster
+    │ │ │ │ ├── elasticsearch-api-svc.yaml
+    │ │ │ │ ├── elasticsearch-data-sts.yaml
+    │ │ │ │ ├── elasticsearch-master-sts.yaml
+    │ │ │
+    │ │ │ ├── single-node
+    │ │ │ │ ├── elasticsearch-api-svc.yaml
+    │ │ │ │ ├── elasticsearch-sts.yaml
+    │ │ │
+    │ │ │ ├── elasticsearch-svc.yaml
+    │ │
+    │ │ ├── kibana
+    │ │ │ ├── kibana-deploy.yaml
+    │ │ │ ├── kibana-svc.yaml
+    │ │ │ ├── nginx-deploy.yaml
+    │ │ │ ├── nginx-svc.yaml
+    │ │  
+    │ │ ├── logstash
+    │ │ │ ├── logstash-deploy.yaml
+    │ │ │ ├── logstash-svc.yaml
+    │
+    │ ├── wazuh_managers
+    │ │ ├── wazuh-cluster-svc.yaml
+    │ │ ├── wazuh-master-conf.yaml
+    │ │ ├── wazuh-master-sts.yaml
+    │ │ ├── wazuh-master-svc.yaml
+    │ │ ├── wazuh-worker-0-conf.yaml
+    │ │ ├── wazuh-worker-0-sts.yaml
+    │ │ ├── wazuh-worker-1-conf.yaml
+    │ │ ├── wazuh-worker-1-sts.yaml
+    │ │ ├── wazuh-workers-svc.yaml
+    │ │
+    │ ├── README.md
+    │ ├── VERSION
+    │ ├── CHANGELOG.md
+    │ ├── LICENSE    
+    │ ├── cleanup.md
+    │ ├── instructions.md
+    │ ├── upgrade.md
+
 ## Branches
 
 * `master` branch contains the latest code, be aware of possible bugs on this branch.

--- a/elastic_stack/elasticsearch/cluster/elasticsearch-data-sts.yaml
+++ b/elastic_stack/elasticsearch/cluster/elasticsearch-data-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.0'
+          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/elastic_stack/elasticsearch/cluster/elasticsearch-master-sts.yaml
+++ b/elastic_stack/elasticsearch/cluster/elasticsearch-master-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.0'
+          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/elastic_stack/elasticsearch/single-node/elasticsearch-sts.yaml
+++ b/elastic_stack/elasticsearch/single-node/elasticsearch-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true    
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.0'
+          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/elastic_stack/kibana/kibana-deploy.yaml
+++ b/elastic_stack/kibana/kibana-deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: wazuh-kibana
-          image: 'wazuh/wazuh-kibana:3.7.0_6.5.0'
+          image: 'wazuh/wazuh-kibana:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 200m

--- a/elastic_stack/kibana/nginx-deploy.yaml
+++ b/elastic_stack/kibana/nginx-deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: wazuh-nginx
-          image: 'wazuh/wazuh-nginx:3.7.0_6.5.0'
+          image: 'wazuh/wazuh-nginx:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 100m

--- a/elastic_stack/logstash/logstash-deploy.yaml
+++ b/elastic_stack/logstash/logstash-deploy.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: wazuh-logstash
-          image: 'wazuh/wazuh-logstash:3.7.0_6.5.0'
+          image: 'wazuh/wazuh-logstash:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh_managers/wazuh-master-sts.yaml
@@ -33,7 +33,7 @@ spec:
             name: wazuh-manager-master-conf
       containers:
         - name: wazuh-manager
-          image: 'wazuh/wazuh:3.7.0_6.5.0'
+          image: 'wazuh/wazuh:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/wazuh_managers/wazuh-worker-0-sts.yaml
+++ b/wazuh_managers/wazuh-worker-0-sts.yaml
@@ -47,7 +47,7 @@ spec:
             name: wazuh-manager-worker-0-conf
       containers:
         - name: wazuh-manager
-          image: 'wazuh/wazuh:3.7.0_6.5.0'
+          image: 'wazuh/wazuh:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 500m

--- a/wazuh_managers/wazuh-worker-1-sts.yaml
+++ b/wazuh_managers/wazuh-worker-1-sts.yaml
@@ -47,7 +47,7 @@ spec:
             name: wazuh-manager-worker-1-conf
       containers:
         - name: wazuh-manager
-          image: 'wazuh/wazuh:3.7.0_6.5.0'
+          image: 'wazuh/wazuh:3.7.2_6.5.4'
           resources:
             requests:
               cpu: 500m


### PR DESCRIPTION
Hello team,

We have updated the version of the images used to create the pods to 3.7.2_6.5.4 version.

Additionally, we have added the directory structure to the README.md file to maintain consistency with the other repositories. 

Kind regards,

Alfonso Ruiz-Bravo