### PR TITLE
Availability Zone us-east-2b

### DIFF
--- a/base/aws-gp2-storage-class.yaml
+++ b/base/aws-gp2-storage-class.yaml
@@ -15,4 +15,5 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   encrypted: 'true'
   type: gp2
+  zone: "us-east-1a"
 reclaimPolicy: Retain  # Useful in case you delete the PersistentVolumeClaim

--- a/base/aws-gp2-storage-class.yaml
+++ b/base/aws-gp2-storage-class.yaml
@@ -15,5 +15,5 @@ provisioner: kubernetes.io/aws-ebs
 parameters:
   encrypted: 'true'
   type: gp2
-  zone: "us-east-1a"
+  zone: "us-east-2b"
 reclaimPolicy: Retain  # Useful in case you delete the PersistentVolumeClaim


### PR DESCRIPTION
Hello team,

Due to the impossibility of communicating STS pods with volumes located in different availability zones (AZs) we have established the deployment of workers nodes in zone b.

This problem is solved in Kubernetes version 1.12. When EKS supports this version, this alternative solution will not be necessary. 

Best regards,

Alfonso Ruiz-Bravo 