### PR TITLE
Added Wazuh elasticsearch images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ## [v3.9.0]
 
-- Update to Wazuh version 3.9.0 ([#38](https://github.com/wazuh/wazuh-kubernetes/pull/38))
+- Update to Wazuh version 3.9.0 ([#40](https://github.com/wazuh/wazuh-kubernetes/pull/38))
+
+### Changed
+
+- Use of Wazuh elasticsearch images ([manuasir](https://github.com/manuasir)) [#40](https://github.com/wazuh/wazuh-kubernetes/pull/40)
+
+### Fixed
+
 - Fix broken links of instructions.md ([#34](https://github.com/wazuh/wazuh-kubernetes/pull/34))
 
 

--- a/elastic_stack/elasticsearch/cluster/elasticsearch-data-sts.yaml
+++ b/elastic_stack/elasticsearch/cluster/elasticsearch-data-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.7.2'
+          image: 'wazuh/wazuh-elasticsearch:3.9.0_6.7.2'
           resources:
             requests:
               cpu: 500m

--- a/elastic_stack/elasticsearch/cluster/elasticsearch-master-sts.yaml
+++ b/elastic_stack/elasticsearch/cluster/elasticsearch-master-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.7.2'
+          image: 'wazuh/wazuh-elasticsearch:3.9.0_6.7.2'
           resources:
             requests:
               cpu: 500m

--- a/elastic_stack/elasticsearch/single-node/elasticsearch-sts.yaml
+++ b/elastic_stack/elasticsearch/single-node/elasticsearch-sts.yaml
@@ -52,7 +52,7 @@ spec:
             privileged: true    
       containers:
         - name: wazuh-elasticsearch
-          image: 'docker.elastic.co/elasticsearch/elasticsearch:6.7.2'
+          image: 'wazuh/wazuh-elasticsearch:3.9.0_6.7.2'
           resources:
             requests:
               cpu: 500m

--- a/instructions.md
+++ b/instructions.md
@@ -29,7 +29,7 @@ This pod contains the master node of the Wazuh cluster. The master node centrali
 The management is performed only in this node, so the agent registration service (authd) and the API are placed here.
 
 Details:
-- Image: Docker Hub 'wazuh/wazuh:3.7.0_6.5.0'
+- Image: Docker Hub 'wazuh/wazuh:3.9.0_6.7.2'
 - Controller: StatefulSet
 
 #### Wazuh worker 0 / 1
@@ -37,7 +37,7 @@ Details:
 These pods contain a worker node of the Wazuh cluster. They will receive the agent events.
 
 Details:
-- Image: Docker Hub 'wazuh/wazuh:3.7.0_6.5.0'
+- Image: Docker Hub 'wazuh/wazuh:3.9.0_6.7.2'
 - Controller: StatefulSet
 
 
@@ -46,7 +46,7 @@ Details:
 Elasticsearch pod. It receives and stores alerts received from Logstash. No Elasticsearch cluster is supported yet.
 
 Details:
-- Image: docker.elastic.co/elasticsearch/elasticsearch:6.5.0
+- Image: wazuh/wazuh-elasticsearch:3.9.0_6.7.2
 - Controller: StatefulSet
 
 
@@ -55,7 +55,7 @@ Details:
 Logstash pod. It receives the alerts from each Filebeat located in every Wazuh manager. Then, the alerts are sent to Elasticsearch.
 
 Details:
-- image: Docker Hub 'wazuh/logstash:3.7.0_6.5.0'
+- image: Docker Hub 'wazuh/logstash:3.9.0_6.7.2'
 - Controller: Deployment
 
 
@@ -64,7 +64,7 @@ Details:
 Kibana pod. It lets you visualize your Elasticsearch data, along with other features as the Wazuh app.
 
 Details:
-- image: Docker Hub 'wazuh/kibana:3.7.0_6.5.0'
+- image: Docker Hub 'wazuh/kibana:3.9.0_6.7.2'
 - Controller: Deployment
 
 #### Nginx
@@ -72,7 +72,7 @@ Details:
 The nginx pod acts as a reverse proxy for a safer access to Kibana.
 
 Details:
-- image: Docker Hub 'wazuh/nginx:3.7.0_6.5.0'
+- image: Docker Hub 'wazuh/nginx:3.9.0_6.7.2'
 - Controller: Deployment
 
 

--- a/upgrade.md
+++ b/upgrade.md
@@ -27,12 +27,12 @@ Any file that we modify referring to the files previously mentioned, will be cha
 
 To better understand it, we will give an example:
 
-We have our newly created Kubernetes environment following our instructions. In this example, the image of Wazuh used has been `wazuh/wazuh:3.6.1_6.4.0`.
+We have our newly created Kubernetes environment following our instructions. In this example, the image of Wazuh used has been `wazuh/wazuh:3.9.0_6.7.2`.
 
 ```
 containers:
 - name: wazuh-manager
-  image: 'wazuh/wazuh:3.6.1_6.4.0'
+  image: 'wazuh/wazuh:3.9.0_6.7.2'
 ```
 
 Let's proceed by creating a set of rules in our `local_rules.xml` file at location `/var/ossec/etc/rules` in our wazuh manager master pod. 
@@ -179,7 +179,7 @@ For example we had this version before:
 ```
 containers:
 - name: wazuh-manager
-  image: 'wazuh/wazuh:3.6.1_6.4.0'
+  image: 'wazuh/wazuh:3.8.2_6.5.4'
 ```
 
 And now we're going to upgrade to the next version: 
@@ -187,7 +187,7 @@ And now we're going to upgrade to the next version:
 ```
 containers:
 - name: wazuh-manager
-  image: 'wazuh/wazuh:3.7.0_6.5.0'
+  image: 'wazuh/wazuh:3.9.0_6.7.2'
 ```
 
 


### PR DESCRIPTION
Hello team,

This PR solves #39 , now `Wazuh elasticsearch` images are used instead of images from `Elastic`.
Also, the documents were updated to the latest versions.

Regards