### PR TITLE
Increase Kibana max-old-space-size

### DIFF
--- a/elastic_stack/kibana/kibana-deploy.yaml
+++ b/elastic_stack/kibana/kibana-deploy.yaml
@@ -32,7 +32,7 @@ spec:
               memory: 512Mi
             limits:
               cpu: 400m
-              memory: 1024Mi
+              memory: 2048Mi
           ports:
             - containerPort: 5601
               name: kibana
@@ -40,4 +40,4 @@ spec:
             - name: ELASTICSEARCH_URL
               value: 'http://elasticsearch:9200'
             - name: NODE_OPTIONS
-              value: '--max-old-space-size=512'
+              value: '--max-old-space-size=2048'


### PR DESCRIPTION
Hello team,

This PR closes #97 by increasing the value of `max-old-space-size` in the Kibana service deploy file.

Regards,
Daniel Folch