### PR TITLE
Bump local-environment and fix resource limits

### DIFF
--- a/minikube/elastic/elasticsearch-sts.yaml
+++ b/minikube/elastic/elasticsearch-sts.yaml
@@ -51,7 +51,7 @@ spec:
             privileged: true    
       containers:
         - name: wazuh-elasticsearch
-          image: 'wazuh/wazuh-elasticsearch:3.13.0_7.7.1'
+          image: 'wazuh/wazuh-elasticsearch:3.13.1_7.8.0'
           resources:
             requests:
               cpu: 500m

--- a/minikube/kibana/kibana-deploy.yaml
+++ b/minikube/kibana/kibana-deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: wazuh-kibana
-          image: 'wazuh/wazuh-kibana:3.13.0_7.7.1'
+          image: 'wazuh/wazuh-kibana:3.13.1_7.8.0'
           resources:
             requests:
               cpu: 200m

--- a/minikube/kibana/kibana-deploy.yaml
+++ b/minikube/kibana/kibana-deploy.yaml
@@ -28,10 +28,10 @@ spec:
           resources:
             requests:
               cpu: 200m
-              memory: 512Mi
+              memory: 1024Mi
             limits:
               cpu: 400m
-              memory: 1024Mi
+              memory: 2048Mi
           ports:
             - containerPort: 5601
               name: kibana
@@ -39,4 +39,4 @@ spec:
             - name: ELASTICSEARCH_URL
               value: 'http://elasticsearch:9200'
             - name: NODE_OPTIONS
-              value: '--max-old-space-size=512'
+              value: '--max-old-space-size=2048'

--- a/minikube/kibana/nginx-deploy.yaml
+++ b/minikube/kibana/nginx-deploy.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
         - name: wazuh-nginx
-          image: 'wazuh/wazuh-nginx:3.13.0_7.7.1'
+          image: 'wazuh/wazuh-nginx:3.13.1_7.8.0'
           resources:
             requests:
               cpu: 100m

--- a/minikube/wazuh/wazuh-sts.yaml
+++ b/minikube/wazuh/wazuh-sts.yaml
@@ -29,7 +29,7 @@ spec:
             name: wazuh-manager-conf
       containers:
         - name: wazuh-manager
-          image: 'wazuh/wazuh:3.13.0_7.7.1'
+          image: 'wazuh/wazuh:3.13.1_7.8.0'
           resources:
             requests:
               cpu: 2


### PR DESCRIPTION
This PR bumps local-env branch to latest version 3.13.1_7.8.0 and fixes resource limits on the Kibana service, incresing max-old-space-size to 2048.