### PR TITLE
Using Kubernetes secrets to store credentials

### DIFF
--- a/secrets/wazuh-api-cred-secret.yaml
+++ b/secrets/wazuh-api-cred-secret.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2020 Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Wazuh API credentials secret
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wazuh-api-cred
+data:
+  username: Zm9v # string "foo" base64 encoded
+  password: YmFy # string "bar" base64 encoded

--- a/secrets/wazuh-authd-pass-secret.yaml
+++ b/secrets/wazuh-authd-pass-secret.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Wazuh authd password secret
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wazuh-authd-pass
+data:
+  authd.pass: cGFzc3dvcmQ= # string "password" base64 encoded

--- a/secrets/wazuh-cluster-key-secret.yaml
+++ b/secrets/wazuh-cluster-key-secret.yaml
@@ -1,0 +1,15 @@
+# Copyright (C) 2020 Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Wazuh cluster key secret
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: wazuh-cluster-key
+data:
+  key: MTIzYTQ1YmM2N2RlZjg5MWdoMjNpNDVqazY3bDhtbjk= # string "123a45bc67def891gh23i45jk67l8mn9" base64 encoded

--- a/wazuh_managers/wazuh-master-conf.yaml
+++ b/wazuh_managers/wazuh-master-conf.yaml
@@ -302,7 +302,7 @@ data:
         <force_insert>no</force_insert>
         <force_time>0</force_time>
         <purge>no</purge>
-        <use_password>no</use_password>
+        <use_password>yes</use_password>
         <limit_maxagents>yes</limit_maxagents>
         <ciphers>HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH</ciphers>
         <!-- <ssl_agent_ca></ssl_agent_ca> -->

--- a/wazuh_managers/wazuh-master-conf.yaml
+++ b/wazuh_managers/wazuh-master-conf.yaml
@@ -316,8 +316,7 @@ data:
         <name>wazuh</name>
         <node_name>wazuh-manager-master</node_name>
         <node_type>master</node_type>
-        <!-- TODO: Don't hardcode the key! (and change it) -->
-        <key>123a45bc67def891gh23i45jk67l8mn9</key>
+        <key>to_be_replaced_by_cluster_key</key>
         <port>1516</port>
         <bind_addr>0.0.0.0</bind_addr>
         <nodes>

--- a/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh_managers/wazuh-master-sts.yaml
@@ -73,6 +73,11 @@ spec:
                 secretKeyRef:
                   name: wazuh-api-cred
                   key: password
+            - name: WAZUH_CLUSTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-cluster-key
+                  key: key
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-master

--- a/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh_managers/wazuh-master-sts.yaml
@@ -31,6 +31,9 @@ spec:
         - name: config
           configMap:
             name: wazuh-manager-master-conf
+        - name: wazuh-authd-pass
+          secret:
+            secretName: wazuh-authd-pass
       containers:
         - name: wazuh-manager
           image: 'wazuh/wazuh:3.13.2_7.9.1'
@@ -48,6 +51,10 @@ spec:
               readOnly: true
             - name: wazuh-manager-master
               mountPath: /var/ossec/data
+            - name: wazuh-authd-pass
+              mountPath: /wazuh-config-mount/etc/authd.pass
+              subPath: authd.pass
+              readOnly: true
           ports:
             - containerPort: 1515
               name: registration

--- a/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh_managers/wazuh-master-sts.yaml
@@ -62,6 +62,17 @@ spec:
               name: cluster
             - containerPort: 55000
               name: api
+          env:
+            - name: API_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: username
+            - name: API_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: password
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-master

--- a/wazuh_managers/wazuh-worker-conf.yaml
+++ b/wazuh_managers/wazuh-worker-conf.yaml
@@ -316,8 +316,7 @@ data:
         <name>wazuh</name>
         <node_name>to_be_replaced_by_hostname</node_name>
         <node_type>worker</node_type>
-        <!-- TODO: Don't hardcode the key! (and change it) -->
-        <key>123a45bc67def891gh23i45jk67l8mn9</key>
+        <key>to_be_replaced_by_cluster_key</key>
         <port>1516</port>
         <bind_addr>0.0.0.0</bind_addr>
         <nodes>

--- a/wazuh_managers/wazuh-worker-sts.yaml
+++ b/wazuh_managers/wazuh-worker-sts.yaml
@@ -59,6 +59,17 @@ spec:
               name: agents-events
             - containerPort: 1516
               name: cluster
+          env:
+            - name: API_USER
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: username
+            - name: API_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-api-cred
+                  key: password
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-worker

--- a/wazuh_managers/wazuh-worker-sts.yaml
+++ b/wazuh_managers/wazuh-worker-sts.yaml
@@ -70,6 +70,11 @@ spec:
                 secretKeyRef:
                   name: wazuh-api-cred
                   key: password
+            - name: WAZUH_CLUSTER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: wazuh-cluster-key
+                  key: key
   volumeClaimTemplates:
     - metadata:
         name: wazuh-manager-worker


### PR DESCRIPTION
Using Kubernetes secrets for storing various credentials (Issue: #29)

- [x] API password
- [x] Authd password
- [x] Wazuh Cluster keys
- [ ] Kibana username & password

### Changes
- Added `Secret` object for each credential
- Mounted Wazuh authd password in master pod
- Storing all other keys as environment variables
- Replacing cluster key placeholder in docker entrypoint script (https://github.com/wazuh/wazuh-docker/pull/393)
