### PR TITLE
Adopt Wazuh standard on tool names

### DIFF
--- a/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh_managers/wazuh_conf/master.conf
@@ -306,9 +306,9 @@
     <rule_dir>etc/rules</rule_dir>
   </ruleset>
 
-  <!-- Configuration for ossec-authd
+  <!-- Configuration for wazuh-authd
     To enable this service, run:
-    ossec-control enable auth
+    wazuh-control enable auth
   -->
   <auth>
     <disabled>no</disabled>

--- a/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh_managers/wazuh_conf/worker.conf
@@ -305,9 +305,9 @@
     <rule_dir>etc/rules</rule_dir>
   </ruleset>
 
-  <!-- Configuration for ossec-authd
+  <!-- Configuration for wazuh-authd
     To enable this service, run:
-    ossec-control enable auth
+    wazuh-control enable auth
   -->
   <auth>
     <disabled>no</disabled>


### PR DESCRIPTION
This PR closes #129 and #134

## Changes

- Update references to deprecated `ossec-` prefix in favor of `wazuh-` prefix