### PR TITLE
Use relative DNS name for master manager

### DIFF
--- a/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh_managers/wazuh_conf/master.conf
@@ -335,7 +335,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>wazuh-manager-master-0.wazuh-cluster.wazuh.svc.cluster.local</node>
+        <node>wazuh-manager-master-0.wazuh-cluster.wazuh</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>no</disabled>

--- a/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh_managers/wazuh_conf/worker.conf
@@ -334,7 +334,7 @@
     <port>1516</port>
     <bind_addr>0.0.0.0</bind_addr>
     <nodes>
-        <node>wazuh-manager-master-0.wazuh-cluster.wazuh.svc.cluster.local</node>
+        <node>wazuh-manager-master-0.wazuh-cluster.wazuh</node>
     </nodes>
     <hidden>no</hidden>
     <disabled>no</disabled>


### PR DESCRIPTION
This PR fixes #133 

### Changes:

- Refer to master manager using relative DNS instead of FQDN