### PR TITLE
Change admin cert DN to match config in elasticsearch.yml

### DIFF
--- a/wazuh/certs/odfe_cluster/generate_certs.sh
+++ b/wazuh/certs/odfe_cluster/generate_certs.sh
@@ -21,7 +21,7 @@ openssl pkcs8 -inform PEM -outform PEM -in admin-key-temp.pem -topk8 -nocrypt -v
 
 echo "create: admin.csr"
 
-openssl req -days 3650 -new -key admin-key.pem -out admin.csr -subj "/C=US/L=California/O=CompanyUS/CN=admin"
+openssl req -days 3650 -new -key admin-key.pem -out admin.csr -subj "/C=US/L=California/O=Company/CN=admin"
 
 echo "create: admin.pem"
 


### PR DESCRIPTION
The DN of the the generated admin cert does not match what's configured in [elasticsearch.yml](https://github.com/wazuh/wazuh-kubernetes/blob/381a08e569bf2acfd2ce1bc5a619021eb80bc0b2/wazuh/elastic_stack/elasticsearch/elastic_conf/elasticsearch.yml#L21), which causes an error if you try and run `securityadmin.sh`.