### PR TITLE
Local environment resources update

### DIFF
--- a/envs/local-env/indexer-resources.yaml
+++ b/envs/local-env/indexer-resources.yaml
@@ -12,3 +12,14 @@ metadata:
   namespace: wazuh
 spec:
   replicas: 1
+  template:
+    spec:
+      containers:
+        - name: wazuh-indexer
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1
+              memory: 2Gi


### PR DESCRIPTION
This PR increase the memory resources assigned to the Wazuh indexer container because it was throwing OOM errors.