### PR TITLE
Indexer container memory limit increased

### DIFF
--- a/wazuh/indexer_stack/wazuh-indexer/cluster/indexer-sts.yaml
+++ b/wazuh/indexer_stack/wazuh-indexer/cluster/indexer-sts.yaml
@@ -63,7 +63,7 @@ spec:
           resources:
             limits:
               cpu: 500m
-              memory: 1Gi
+              memory: 1564Mi
           env:
             - name: ES_JAVA_OPTS
               value: '-Xms1g -Xmx1g -Dlog4j2.formatMsgNoLookups=true'


### PR DESCRIPTION
This issue is related to #189 and #220. Default indexer memory limit is not enough and an OOM error is raised.