### PR TITLE
dashboard-cred secrect added

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The [instructions.md](instructions.md) file describes how to deploy Wazuh on Kub
         │       └── indexer-svc.yaml
         ├── kustomization.yml
         ├── secrets
+        │   ├── dashboard-cred-secret.yaml
         │   ├── indexer-cred-secret.yaml
         │   ├── wazuh-api-cred-secret.yaml
         │   ├── wazuh-authd-pass-secret.yaml

--- a/wazuh/indexer_stack/wazuh-dashboard/dashboard-deploy.yaml
+++ b/wazuh/indexer_stack/wazuh-dashboard/dashboard-deploy.yaml
@@ -70,6 +70,16 @@ spec:
                 secretKeyRef:
                   name: indexer-cred
                   key: password
+            - name: DASHBOARD_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-cred
+                  key: username
+            - name: DASHBOARD_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: dashboard-cred
+                  key: password
             - name: SERVER_SSL_ENABLED
               value: "true"
             - name: SERVER_SSL_CERTIFICATE

--- a/wazuh/kustomization.yml
+++ b/wazuh/kustomization.yml
@@ -49,6 +49,7 @@ resources:
   - secrets/wazuh-api-cred-secret.yaml
   - secrets/wazuh-authd-pass-secret.yaml
   - secrets/wazuh-cluster-key-secret.yaml
+  - secrets/dashboard-cred-secret.yaml
   - secrets/indexer-cred-secret.yaml
 
   - wazuh_managers/wazuh-cluster-svc.yaml


### PR DESCRIPTION
This PR closes #248 
This was tested using Docker 4.3.0 images generated with branch [640-kibana_user_parameter](https://github.com/wazuh/wazuh-docker/tree/640-kibana_user_parameter). 
Procedure description:
1. Deploy Wazuh using kubernetes repository.
2. Modify the `kibanaserver` hash in `internal_users.yml` configmap.
3. Modify the base64 `dashboard-cred` `password`.
4. Redeploy Wazuh using kubernetes repository.
5. Delete Dashboard pod.
6. Access Wazuh dashboard using a browser.