### PR TITLE
Create dashboard-cred-secret.yaml

### DIFF
--- a/wazuh/secrets/dashboard-cred-secret.yaml
+++ b/wazuh/secrets/dashboard-cred-secret.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2021 Wazuh Inc.
+#
+# This program is a free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public
+# License (version 2) as published by the FSF - Free Software
+# Foundation.
+
+# Dashboard credentials secret
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: dashboard-cred
+data:
+  username: YWRtaW4=              # string "admin" base64 encoded
+  password: U2VjcmV0UGFzc3dvcmQ=  # string "SecretPassword" base64 encoded


### PR DESCRIPTION
Related issue: https://github.com/wazuh/wazuh-kubernetes/issues/252 

Description
Project is missing Secret as a result you cannot use kustomize.
This was introduced on https://github.com/wazuh/wazuh-kubernetes/pull/249
Current:
```
kustomize build envs/local-env
Error: accumulating resources: accumulation err='accumulating resources from 'https://github.com/wazuh/wazuh-kubernetes//wazuh/?ref=4.3': URL is a git repository': recursed accumulation of path '/private/var/folders/82/18zvpyl91ll_b00nx726s3880000gq/T/kustomize-3658053503/wazuh': accumulating resources: accumulation err='accumulating resources from 'secrets/dashboard-cred-secret.yaml': evalsymlink failure on '/private/var/folders/82/18zvpyl91ll_b00nx726s3880000gq/T/kustomize-3658053503/wazuh/secrets/dashboard-cred-secret.yaml' : lstat /private/var/folders/82/18zvpyl91ll_b00nx726s3880000gq/T/kustomize-3658053503/wazuh/secrets/dashboard-cred-secret.yaml: no such file or directory': evalsymlink failure on '/private/var/folders/82/18zvpyl91ll_b00nx726s3880000gq/T/kustomize-3658053503/wazuh/secrets/dashboard-cred-secret.yaml' : lstat /private/var/folders/82/18zvpyl91ll_b00nx726s3880000gq/T/kustomize-3658053503/wazuh/secrets/dashboard-cred-secret.yaml: no such file or director
```

Expected:
XML output

Checks:
Compiles without warmings.
