### PR TITLE
fix permission issue for /var/ossec/var/multigroups

### DIFF
--- a/wazuh/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh/wazuh_managers/wazuh-master-sts.yaml
@@ -37,6 +37,8 @@ spec:
         - name: wazuh-authd-pass
           secret:
             secretName: wazuh-authd-pass
+      securityContext:
+        fsGroup: 101
       containers:
         - name: wazuh-manager
           image: 'wazuh/wazuh-manager:4.3.3'

--- a/wazuh/wazuh_managers/wazuh-worker-sts.yaml
+++ b/wazuh/wazuh_managers/wazuh-worker-sts.yaml
@@ -40,6 +40,8 @@ spec:
         - name: filebeat-certs
           secret:
             secretName: indexer-certs
+      securityContext:
+        fsGroup: 101
       containers:
         - name: wazuh-manager
           image: 'wazuh/wazuh-manager:4.3.3'


### PR DESCRIPTION
Hi Wazuh Contributors, 

Post K8S deployment on EKS, my agents could not synchronize newly created groups(agent.conf).
My deployment is based on branch: v4.3.3 


After examining the logs on master and worker nodes I've noticed the following err msg:
`Jun 21, 2022 @ 11:36:20.000 wazuh-remoted ERROR  Cannot create multigroup directory 'var/multigroups/2ce0beec': Permission denied (13)`
![image](https://user-images.githubusercontent.com/48384761/174778741-5c8844c1-1a3a-4dd4-839a-ec56b4bd73e3.png)

Steps to reproduce:

- Deploy branch v4.3.3
- Install at least one agent on target machine
- Create a new group via Wazuh Dashboard (UI)
- Assign the group to newly created agent (I've used [agent_groups](https://documentation.wazuh.com/current/user-manual/reference/tools/agent-groups.html#agent-groups) cli)
- Agent won't be synchronized

In order to fix the issue, I've sshed to the containers and changed the ownership of the folder.
The following PR is a suggestion for a permanent fix.

FYI, If someone encountered this issue, feel free to use the following Kustomize patch:


```
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: wazuh-manager-master
  namespace: wazuh
spec:
  selector:
    matchLabels:
      app: wazuh-manager
      node-type: master
  template:
    spec:
      securityContext:
        fsGroup: 101
---
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: wazuh-manager-worker
  namespace: wazuh
spec:
  selector:
    matchLabels:
      app: wazuh-manager
      node-type: worker
  template:
    spec:
      securityContext:
        fsGroup: 101
```

