### PR TITLE
fix #283 - multigroups directory has wrong permission/owner

### DIFF
--- a/wazuh/wazuh_managers/wazuh-master-sts.yaml
+++ b/wazuh/wazuh_managers/wazuh-master-sts.yaml
@@ -37,6 +37,16 @@ spec:
         - name: wazuh-authd-pass
           secret:
             secretName: wazuh-authd-pass
+      initContainers:
+        - name: config-permissions
+          image: 'busybox'
+          # change owner of `multigroups` to `root:wazuh` (wazuh uid: 101)
+          # and change permission to `770`, same as other directories in `/var/ossec/var`
+          command: ['sh', '-c', 'chown root:101 -R /var/ossec/var/multigroups && chmod 770 /var/ossec/var/multigroups']
+          volumeMounts:
+            - name: wazuh-manager-master
+              mountPath: /var/ossec/var/multigroups
+              subPath: wazuh/var/ossec/var/multigroups
       containers:
         - name: wazuh-manager
           image: 'wazuh/wazuh-manager:4.5.0'

--- a/wazuh/wazuh_managers/wazuh-worker-sts.yaml
+++ b/wazuh/wazuh_managers/wazuh-worker-sts.yaml
@@ -40,6 +40,16 @@ spec:
         - name: filebeat-certs
           secret:
             secretName: indexer-certs
+      initContainers:
+        - name: config-permissions
+          image: 'busybox'
+          # change owner of `multigroups` to `root:wazuh` (wazuh uid: 101)
+          # and change permission to `770`, same as other directories in `/var/ossec/var`
+          command: ['sh', '-c', 'chown root:101 -R /var/ossec/var/multigroups && chmod 770 /var/ossec/var/multigroups']
+          volumeMounts:
+            - name: wazuh-manager-worker
+              mountPath: /var/ossec/var/multigroups
+              subPath: wazuh/var/ossec/var/multigroups
       containers:
         - name: wazuh-manager
           image: 'wazuh/wazuh-manager:4.5.0'


### PR DESCRIPTION
Fix #283 
- add init container to configure proper permission/owner for `var/multigroups` directory