### PR TITLE
Firewall-drop command config update

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -222,8 +222,7 @@
 
   <command>
     <name>firewall-drop</name>
-    <executable>firewall-drop.sh</executable>
-    <expect>srcip</expect>
+    <executable>firewall-drop</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
@@ -269,11 +268,12 @@
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
-  <!--
   <active-response>
-    active-response options here
+    <command>firewall-drop</command>
+    <location>local</location>
+    <rules_id>5712</rules_id>
+    <timeout>1800</timeout>
   </active-response>
-  -->
 
   <!-- Log analysis -->
   <localfile>

--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -274,7 +274,6 @@
   </active-response>
   -->
 
-
   <!-- Log analysis -->
   <localfile>
     <log_format>command</log_format>

--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -268,12 +268,12 @@
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
+  <!--
   <active-response>
-    <command>firewall-drop</command>
-    <location>local</location>
-    <rules_id>5712</rules_id>
-    <timeout>1800</timeout>
+    active-response options here
   </active-response>
+  -->
+
 
   <!-- Log analysis -->
   <localfile>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -267,12 +267,11 @@
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
+  <!--
   <active-response>
-    <command>firewall-drop</command>
-    <location>local</location>
-    <rules_id>5712</rules_id>
-    <timeout>1800</timeout>
+    active-response options here
   </active-response>
+  -->
 
   <!-- Log analysis -->
   <localfile>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -221,8 +221,7 @@
 
   <command>
     <name>firewall-drop</name>
-    <executable>firewall-drop.sh</executable>
-    <expect>srcip</expect>
+    <executable>firewall-drop</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
@@ -268,11 +267,12 @@
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
-  <!--
   <active-response>
-    active-response options here
+    <command>firewall-drop</command>
+    <location>local</location>
+    <rules_id>5712</rules_id>
+    <timeout>1800</timeout>
   </active-response>
-  -->
 
   <!-- Log analysis -->
   <localfile>


### PR DESCRIPTION
This PR updated the `firewall-drop` command configuration according to the documentation:
- https://documentation.wazuh.com/current/user-manual/capabilities/active-response/ar-use-cases/blocking-attacks.html

We noticed this thanks to a community in slack.