### PR TITLE
Firewall drop script name update (4.4)

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -222,7 +222,7 @@
 
   <command>
     <name>firewall-drop</name>
-    <executable>firewall-drop.sh</executable>
+    <executable>firewall-drop</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -221,7 +221,7 @@
 
   <command>
     <name>firewall-drop</name>
-    <executable>firewall-drop.sh</executable>
+    <executable>firewall-drop</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 


### PR DESCRIPTION
This PR fixes the `firewall-drop` script name in branch `4.4`.