### PR TITLE
Updating vulnerability detector default configuration with AlmaLinux support

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -137,6 +137,14 @@
         <update_interval>1h</update_interval>
       </provider>
 
+      <!-- Alma Linux OS vulnerabilities -->
+      <provider name="almalinux">
+        <enabled>no</enabled>
+        <os>8</os>
+        <os>9</os>
+        <update_interval>1h</update_interval>
+      </provider>
+
       <!-- Windows OS vulnerabilities -->
       <provider name="msu">
         <enabled>yes</enabled>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -137,6 +137,14 @@
         <update_interval>1h</update_interval>
       </provider>
 
+      <!-- Alma Linux OS vulnerabilities -->
+      <provider name="almalinux">
+        <enabled>no</enabled>
+        <os>8</os>
+        <os>9</os>
+        <update_interval>1h</update_interval>
+      </provider>
+
       <!-- Windows OS vulnerabilities -->
       <provider name="msu">
         <enabled>yes</enabled>


### PR DESCRIPTION
## Description

This PR adds the corresponding AlmaLinux entry in the vulnerability detector default configuration after the changes in [Add support for AlmaLinux in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/16343#top)
#16343.

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new AlmaLinux provider