### PR TITLE
Update the vulnerability detector default configuration block with missing providers

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -104,54 +104,80 @@
   </wodle>
 
   <vulnerability-detector>
+    <enabled>no</enabled>
+    <interval>5m</interval>
+    <min_full_scan_interval>6h</min_full_scan_interval>
+    <run_on_start>yes</run_on_start>
+
+    <!-- Ubuntu OS vulnerabilities -->
+    <provider name="canonical">
       <enabled>no</enabled>
-      <interval>5m</interval>
-      <ignore_time>6h</ignore_time>
-      <run_on_start>yes</run_on_start>
+      <os>trusty</os>
+      <os>xenial</os>
+      <os>bionic</os>
+      <os>focal</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Ubuntu OS vulnerabilities -->
-      <provider name="canonical">
-        <enabled>no</enabled>
-        <os>trusty</os>
-        <os>xenial</os>
-        <os>bionic</os>
-        <os>focal</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Debian OS vulnerabilities -->
+    <provider name="debian">
+      <enabled>no</enabled>
+      <os>stretch</os>
+      <os>buster</os>
+      <os>bullseye</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Debian OS vulnerabilities -->
-      <provider name="debian">
-        <enabled>no</enabled>
-        <os>stretch</os>
-        <os>buster</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- RedHat OS vulnerabilities -->
+    <provider name="redhat">
+      <enabled>no</enabled>
+      <os>5</os>
+      <os>6</os>
+      <os>7</os>
+      <os>8</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- RedHat OS vulnerabilities -->
-      <provider name="redhat">
-        <enabled>no</enabled>
-        <os>5</os>
-        <os>6</os>
-        <os>7</os>
-        <os>8</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Amazon Linux OS vulnerabilities -->
+    <provider name="alas">
+      <enabled>no</enabled>
+      <os>amazon-linux</os>
+      <os>amazon-linux-2</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Windows OS vulnerabilities -->
-      <provider name="msu">
-        <enabled>yes</enabled>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- SUSE Linux Enterprise OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Aggregate vulnerabilities -->
-      <provider name="nvd">
-        <enabled>yes</enabled>
-        <update_from_year>2010</update_from_year>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Arch OS vulnerabilities -->
+    <provider name="arch">
+      <enabled>no</enabled>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <!-- Windows OS vulnerabilities -->
+    <provider name="msu">
+      <enabled>yes</enabled>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <!-- Aggregate vulnerabilities -->
+    <provider name="nvd">
+      <enabled>yes</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
 
   </vulnerability-detector>
-
 
   <!-- File integrity monitoring -->
   <syscheck>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -104,51 +104,78 @@
   </wodle>
 
   <vulnerability-detector>
+    <enabled>no</enabled>
+    <interval>5m</interval>
+    <min_full_scan_interval>6h</min_full_scan_interval>
+    <run_on_start>yes</run_on_start>
+
+    <!-- Ubuntu OS vulnerabilities -->
+    <provider name="canonical">
       <enabled>no</enabled>
-      <interval>5m</interval>
-      <ignore_time>6h</ignore_time>
-      <run_on_start>yes</run_on_start>
+      <os>trusty</os>
+      <os>xenial</os>
+      <os>bionic</os>
+      <os>focal</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Ubuntu OS vulnerabilities -->
-      <provider name="canonical">
-        <enabled>no</enabled>
-        <os>trusty</os>
-        <os>xenial</os>
-        <os>bionic</os>
-        <os>focal</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Debian OS vulnerabilities -->
+    <provider name="debian">
+      <enabled>no</enabled>
+      <os>stretch</os>
+      <os>buster</os>
+      <os>bullseye</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Debian OS vulnerabilities -->
-      <provider name="debian">
-        <enabled>no</enabled>
-        <os>stretch</os>
-        <os>buster</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- RedHat OS vulnerabilities -->
+    <provider name="redhat">
+      <enabled>no</enabled>
+      <os>5</os>
+      <os>6</os>
+      <os>7</os>
+      <os>8</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- RedHat OS vulnerabilities -->
-      <provider name="redhat">
-        <enabled>no</enabled>
-        <os>5</os>
-        <os>6</os>
-        <os>7</os>
-        <os>8</os>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Amazon Linux OS vulnerabilities -->
+    <provider name="alas">
+      <enabled>no</enabled>
+      <os>amazon-linux</os>
+      <os>amazon-linux-2</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Windows OS vulnerabilities -->
-      <provider name="msu">
-        <enabled>yes</enabled>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- SUSE Linux Enterprise OS vulnerabilities -->
+    <provider name="suse">
+      <enabled>no</enabled>
+      <os>11-server</os>
+      <os>11-desktop</os>
+      <os>12-server</os>
+      <os>12-desktop</os>
+      <os>15-server</os>
+      <os>15-desktop</os>
+      <update_interval>1h</update_interval>
+    </provider>
 
-      <!-- Aggregate vulnerabilities -->
-      <provider name="nvd">
-        <enabled>yes</enabled>
-        <update_from_year>2010</update_from_year>
-        <update_interval>1h</update_interval>
-      </provider>
+    <!-- Arch OS vulnerabilities -->
+    <provider name="arch">
+      <enabled>no</enabled>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <!-- Windows OS vulnerabilities -->
+    <provider name="msu">
+      <enabled>yes</enabled>
+      <update_interval>1h</update_interval>
+    </provider>
+
+    <!-- Aggregate vulnerabilities -->
+    <provider name="nvd">
+      <enabled>yes</enabled>
+      <update_from_year>2010</update_from_year>
+      <update_interval>1h</update_interval>
+    </provider>
 
   </vulnerability-detector>
 


### PR DESCRIPTION
This PR adds several vd configurations and remove deprecateed options.
Closes https://github.com/wazuh/wazuh-kubernetes/issues/421