### PR TITLE
Add Debian Bookworm to VDT default configuration

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -125,6 +125,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -125,6 +125,7 @@
       <enabled>no</enabled>
       <os>buster</os>
       <os>bullseye</os>
+      <os>bookworm</os>
       <update_interval>1h</update_interval>
     </provider>
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#18516|

## Description

This PR adds the corresponding Debian Bookworm entry in the vulnerability detector default configuration after the changes in [Add support for Debian Bookworm in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/18516)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Debian Bookworm provider