### PR TITLE
Add placeholder files to allow a kustomize build 

### DIFF
--- a/wazuh/certs/dashboard_http/cert.pem
+++ b/wazuh/certs/dashboard_http/cert.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/dashboard_http/key.pem
+++ b/wazuh/certs/dashboard_http/key.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/admin-key.pem
+++ b/wazuh/certs/indexer_cluster/admin-key.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/admin.pem
+++ b/wazuh/certs/indexer_cluster/admin.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/dashboard-key.pem
+++ b/wazuh/certs/indexer_cluster/dashboard-key.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/dashboard.pem
+++ b/wazuh/certs/indexer_cluster/dashboard.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/filebeat-key.pem
+++ b/wazuh/certs/indexer_cluster/filebeat-key.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/filebeat.pem
+++ b/wazuh/certs/indexer_cluster/filebeat.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/node-key.pem
+++ b/wazuh/certs/indexer_cluster/node-key.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/node.pem
+++ b/wazuh/certs/indexer_cluster/node.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh

--- a/wazuh/certs/indexer_cluster/root-ca.pem
+++ b/wazuh/certs/indexer_cluster/root-ca.pem
@@ -1,0 +1,1 @@
+placeholder, please generate a certificate using generate_certs.sh


### PR DESCRIPTION
This allows you to directly include the wazuh base from a remote kustomize setup.

The currently proposed workflow forces you to fork this repository into a private one to make necessary changes.

This should close #251.