### PR TITLE
VD keystore changes

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -114,8 +114,6 @@
     <hosts>
       <host>https://wazuh-indexer-0.wazuh-indexer:9200</host>
     </hosts>
-    <username>admin</username>
-    <password>VDPass</password>
     <ssl>
       <certificate_authorities>
         <ca>/etc/ssl/root-ca.pem</ca>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -114,8 +114,6 @@
     <hosts>
       <host>https://wazuh-indexer-0.wazuh-indexer:9200</host>
     </hosts>
-    <username>admin</username>
-    <password>VDPass</password>
     <ssl>
       <certificate_authorities>
         <ca>/etc/ssl/root-ca.pem</ca>


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-kubernetes/issues/573

The aim of this PR is to adapt the Kubernetes deployment to the new changes of the VD and indexer configuration.  The changes consist in removing the hardcoding of the indexer username password in the `ossec.conf` of the master and workers nodes.

The rest of the changes are done in the Wazuh docker repository: https://github.com/wazuh/wazuh-docker/pull/1196 