### PR TITLE
Merge 4.7.3 into 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 - Update to Wazuh version [4.8.0](https://github.com/wazuh/wazuh/blob/v4.8.0/CHANGELOG.md#v480)
 
+## [4.7.3]
+
+### Added
+
+- Update to Wazuh version [4.7.3](https://github.com/wazuh/wazuh/blob/v4.7.3/CHANGELOG.md#v473)
+
 ## [4.7.2]
 
 ### Added


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-kubernetes/issues/598
The aim of this PR is to bump the 4.7.3 changes into the 4.8.0 branch.