### PR TITLE
Delete syslog and dpkg log configuration

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -330,13 +330,4 @@
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
 </ossec_config>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -330,13 +330,4 @@
     <location>/var/ossec/logs/active-responses.log</location>
   </localfile>
 
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/syslog</location>
-  </localfile>
-
-  <localfile>
-    <log_format>syslog</log_format>
-    <location>/var/log/dpkg.log</location>
-  </localfile>
 </ossec_config>


### PR DESCRIPTION
This PR deletes configuration about`/var/log/syslog` and `/var/log/dpkg.log` into `ossec.conf` file.
Related Issue https://github.com/wazuh/wazuh/issues/22511