### PR TITLE
fix: allow spaces in current working directory on certificate generation

### DIFF
--- a/wazuh/certs/dashboard_http/generate_certs.sh
+++ b/wazuh/certs/dashboard_http/generate_certs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR
+cd "$DIR"
 
 openssl req -x509 -batch -nodes -days 365 -newkey rsa:2048 -keyout key.pem -out cert.pem

--- a/wazuh/certs/indexer_cluster/generate_certs.sh
+++ b/wazuh/certs/indexer_cluster/generate_certs.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd $DIR
+cd "$DIR"
 
 echo "Root CA"
 


### PR DESCRIPTION
If the current working directory includes spaces (even if it should not...), the cert generation script will fail.

Added quotes for the variable use and also `set -e` to fail script fast on error. 