### PR TITLE
Fix opensearch.yaml for 3 replica cluster

### DIFF
--- a/wazuh/indexer_stack/wazuh-indexer/indexer_conf/opensearch.yml
+++ b/wazuh/indexer_stack/wazuh-indexer/indexer_conf/opensearch.yml
@@ -1,10 +1,14 @@
 cluster.name: ${CLUSTER_NAME}
 node.name: ${NODE_NAME}
 network.host: ${NETWORK_HOST}
-discovery.seed_hosts: wazuh-indexer-0.wazuh-indexer
+discovery.seed_hosts: 
+  - wazuh-indexer-0.wazuh-indexer
+  - wazuh-indexer-1.wazuh-indexer
+  - wazuh-indexer-2.wazuh-indexer
 cluster.initial_master_nodes:
   - wazuh-indexer-0
-
+  - wazuh-indexer-1
+  - wazuh-indexer-2
 node.max_local_storage_nodes: "3"
 path.data: /var/lib/wazuh-indexer
 path.logs: /var/log/wazuh-indexer


### PR DESCRIPTION
This commit fixes the issue that when the wazuh-indexer-0 is restarting unexpectedly that it still finds the other nodes to rejoin the cluster. Also allows any of the 3 replicas to become the master.

Without this PR when wazuh-indexer-0 is restarting it won't find the other two nodes of the cluster anymore and never join back the cluster thus rendering the indexer service inoperatable.