### PR TITLE
Add labelSelector 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Add labelSelector ([#872](https://github.com/wazuh/wazuh-kubernetes/pull/872)) \- (Wazuh worker STS)
 
 ### Deleted
 

--- a/wazuh/wazuh_managers/wazuh-worker-sts.yaml
+++ b/wazuh/wazuh_managers/wazuh-worker-sts.yaml
@@ -33,6 +33,10 @@ spec:
             - weight: 100
               podAffinityTerm:
                 topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    app: wazuh-manager
+                    node-type: worker
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
This PR adds a labelSelector into podAffinity statement for a warning generated during deployment.
Related issue https://github.com/wazuh/wazuh-kubernetes/issues/868