### PR TITLE
Add an NGINX reverse proxy to have a unique ip for registration and reporting. 

### DIFF
--- a/wazuh/kustomization.yml
+++ b/wazuh/kustomization.yml
@@ -57,6 +57,7 @@ resources:
   - wazuh_managers/wazuh-workers-svc.yaml
   - wazuh_managers/wazuh-master-sts.yaml
   - wazuh_managers/wazuh-worker-sts.yaml
+  - wazuh_managers/services-router.yaml
 
   - indexer_stack/wazuh-indexer/indexer-svc.yaml
   - indexer_stack/wazuh-indexer/cluster/indexer-api-svc.yaml

--- a/wazuh/wazuh_managers/services-router.yaml
+++ b/wazuh/wazuh_managers/services-router.yaml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-lb-config
+data:
+  nginx.conf: |
+    worker_processes auto;
+
+    events {
+        worker_connections 1024;
+    }
+
+    stream {
+      log_format basic '$remote_addr [$time_local] '
+                        'Protocol: $protocol '
+                        'Status: $status '
+                        'Bytes sent: $bytes_sent '
+                        'Bytes received: $bytes_received '
+                        'Session time: $session_time';
+       upstream master {
+           server wazuh:1515;
+       }
+       upstream workers {
+           hash $remote_addr consistent;
+           server wazuh-workers:1514;
+       }
+       server {
+           listen 1515;
+           proxy_pass master;
+           access_log /dev/stdout basic;
+       }
+       server {
+           listen 1514;
+           proxy_pass workers;
+           # ßaccess_log /dev/stdout basic;
+       }
+    }
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wazuh-loadbalancer
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: wazuh-loadbalancer
+  template:
+    metadata:
+      labels:
+        app: wazuh-loadbalancer
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 1514
+        - containerPort: 1515
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: config
+        configMap:
+          name: nginx-lb-config
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wazuh-loadbalancer
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 1514
+    targetPort: 1514
+    protocol: TCP
+    name: agent-report
+  - port: 1515
+    targetPort: 1515
+    protocol: TCP
+    name: agent-register
+  selector:
+    app: wazuh-loadbalancer


### PR DESCRIPTION
Fixes the https://github.com/wazuh/wazuh-kubernetes/issues/308 https://github.com/wazuh/wazuh-kubernetes/issues/547 https://github.com/wazuh/wazuh-kubernetes/issues/961


The problem is:

Deployments exposes the master service on port 1515 for registration and the workers on port 1514 for agent events:

workers svc  (Lets say IP 1.1.1.1) 
```
    - name: agents-events
      port: 1514
      targetPort: 1514
```

Master svc: (lets say IP 2.2.2.2)

```
    - name: registration
      port: 1515
      targetPort: 1515
```

So far so good. 
problem is an agent with this configuration:

```
  <client>
    <server>
      <address>1.1.1.1</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
...
    <enrollment>
      <enabled>yes</enabled>
      <manager_address>2.2.2.2</manager_address>
...
    </enrollment>
  </client>
```

ends up trying to connect to 1.1.1.1:1515 
So it tries the **agent IP with the master port**:

`wazuh-agentd: ERROR: (1208): Unable to connect to enrollment service at '[1.1.1.1]:1515'`

Even with [failover config](https://documentation.wazuh.com/current/user-manual/wazuh-server-cluster.html#connecting-wazuh-agents-to-the-wazuh-cluster-failover-mode) .  So multiple client blocks with the respective port configured (1414 for the worker IP svc and 1515 for the master)...


```
    <server>
      <address>1.1.1.1</address>
      <port>1514</port>
      <protocol>tcp</protocol>
    </server>
    <server>
      <address>2.2.2.2</address>
      <port>1515</port>
      <protocol>tcp</protocol>
    </server>
```

The client tries to enroll to the first client defined (1.1.1.1) on port 1515 even when this client block has only 1414 ports configured. It ends up failing over the workers to register and vice versa for reporting. So this is not ideal.


I've modified the worker svc also to expose 1515 and configure the  agent to use just the worker ip. (no enrollment configuration). And they  can register and report all good. But it leads to other problems...

Ive also found a [comment](https://github.com/wazuh/wazuh-kubernetes/issues/308#issuecomment-1491831228) there it modifies the master to also expose 1414 and use that IP for all agent communications. but I believe this is not the idea of master/worker .

The problem is this leads to other issues: source IPs are the Kubernetes nodes. I believe the worker is forwarding to the master and after k8s SNAT the outgoing IP is the node IP that messes things up.

