### PR TITLE
EKS EBS CSI storage provider name deprecated

### DIFF
--- a/envs/eks/storage-class.yaml
+++ b/envs/eks/storage-class.yaml
@@ -11,7 +11,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: wazuh-storage
-provisioner: kubernetes.io/aws-ebs
+provisioner: ebs.csi.aws.com
 parameters:
   encrypted: 'true'
   type: gp2


### PR DESCRIPTION
The `provisioner: kubernetes.io/aws-ebs` parameter has been deprecated and removed in the in-tree Amazon cloud provider, commit provides new provider name. Tested with EKS.