### PR TITLE
Add missing `malicious-ioc` ruleset lists

### DIFF
--- a/wazuh/wazuh_managers/wazuh_conf/master.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/master.conf
@@ -272,6 +272,9 @@
     <list>etc/lists/audit-keys</list>
     <list>etc/lists/amazon/aws-sources</list>
     <list>etc/lists/amazon/aws-eventnames</list>
+    <list>etc/lists/malicious-ioc/malicious-ip</list>
+    <list>etc/lists/malicious-ioc/malicious-domains</list>
+    <list>etc/lists/malicious-ioc/malware-hashes</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>

--- a/wazuh/wazuh_managers/wazuh_conf/worker.conf
+++ b/wazuh/wazuh_managers/wazuh_conf/worker.conf
@@ -272,6 +272,9 @@
     <list>etc/lists/audit-keys</list>
     <list>etc/lists/amazon/aws-sources</list>
     <list>etc/lists/amazon/aws-eventnames</list>
+    <list>etc/lists/malicious-ioc/malicious-ip</list>
+    <list>etc/lists/malicious-ioc/malicious-domains</list>
+    <list>etc/lists/malicious-ioc/malware-hashes</list>
 
     <!-- User-defined ruleset -->
     <decoder_dir>etc/decoders</decoder_dir>


### PR DESCRIPTION
# Description

The goal of this PR is to add the new lists to the ruleset section of the configuration file on both the worker and the master nodes.

## Testing 🧪 
For testing purposes, a cluster was deployed and the Kubernetes environment was created in EKS.

You can find the ossec.conf logs in this comment:
- https://github.com/wazuh/wazuh-kubernetes/issues/1090#issuecomment-2955566330