### PR TITLE
Add support for deployments using certmanager or external secrets management

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,23 @@ To deploy a cluster on your local environment (like Minikube, Kind or Microk8s) 
     ├── README.md
     ├── upgrade.md
     ├── VERSION.json
+    ├── overlays
+    |   ├── certmanager
+    |   ├── external-certs
+    |   └── local-certs
     └── wazuh
         ├── base
         │   ├── storage-class.yaml
-        │   └── wazuh-ns.yaml
+        │   ├── wazuh-ns.yaml
+        │   └── kustomization.yaml
         ├── certs
+        │   ├── kustomization.yaml
         │   ├── dashboard_http
         │   │   └── generate_certs.sh
         │   └── indexer_cluster
         │       └── generate_certs.sh
         ├── indexer_stack
+        │   ├── kustomization.yaml
         │   ├── wazuh-dashboard
         │   │   ├── dashboard_conf
         │   │   │   └── opensearch_dashboards.yml
@@ -75,8 +82,10 @@ To deploy a cluster on your local environment (like Minikube, Kind or Microk8s) 
         │   ├── indexer-cred-secret.yaml
         │   ├── wazuh-api-cred-secret.yaml
         │   ├── wazuh-authd-pass-secret.yaml
-        │   └── wazuh-cluster-key-secret.yaml
+        │   ├── wazuh-cluster-key-secret.yaml
+        │   └── kustomization.yaml
         └── wazuh_managers
+            ├── kustomization.yaml
             ├── wazuh-cluster-svc.yaml
             ├── wazuh_conf
             │   ├── master.conf

--- a/instructions.md
+++ b/instructions.md
@@ -110,6 +110,12 @@ $ git clone https://github.com/wazuh/wazuh-kubernetes.git
 $ cd wazuh-kubernetes
 ```
 
+there are three options how to deploy wazuh. 
+1. deploy using generated certificates. Follow instruction in 3.1
+2. deploy using certmanager. This requires certmanager is deployed in the cluster. To deploy cluster please follow [https://cert-manager.io/docs/installation/](https://cert-manager.io/docs/installation/)
+  2.1. deploy using certmanager overlay. `kustomize build overlays/certmanager | kubectl apply -f -`
+3. deploy using external certs (external secrets or other option). `kustomize build overlays/external-certs | kubectl apply -f -`
+
 ### Step 3.1: Setup SSL certificates
 
 You can generate self-signed certificates for the Wazuh indexer cluster using the script at `wazuh/certs/indexer_cluster/generate_certs.sh` or provide your own.

--- a/overlays/certmanager/certmanager/ca-certificate.yaml
+++ b/overlays/certmanager/certmanager/ca-certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wazuh-ca
+  namespace: wazuh
+spec:
+  isCA: true
+  commonName: wazuh-ca
+  secretName: wazuh-ca
+  issuerRef:
+    name: selfsigned-bootstrap
+    kind: Issuer
+
+

--- a/overlays/certmanager/certmanager/certificates.yaml
+++ b/overlays/certmanager/certmanager/certificates.yaml
@@ -1,0 +1,73 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wazuh-dashboard-cert
+  namespace: wazuh
+spec:
+  secretName: dashboard-certs
+  dnsNames:
+    - dashboard
+    - dashboard.wazuh
+    - dashboard.wazuh.svc
+  issuerRef:
+    name: wazuh-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wazuh-indexer-node
+  namespace: wazuh
+spec:
+  secretName: indexer-node
+  commonName: indexer
+  subject:
+    organizations:
+      - Company
+    localities:
+      - California
+    countries:
+      - US
+  issuerRef:
+    name: wazuh-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wazuh-indexer-admin
+  namespace: wazuh
+spec:
+  secretName: indexer-admin
+  commonName: admin
+  subject:
+    organizations:
+      - Company
+    localities:
+      - California
+    countries:
+      - US
+  issuerRef:
+    name: wazuh-ca-issuer
+    kind: Issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: wazuh-filebeat-client
+  namespace: wazuh
+spec:
+  secretName: filebeat-client
+  commonName: filebeat
+  subject:
+    organizations:
+      - Company
+    localities:
+      - California
+    countries:
+      - US
+  issuerRef:
+    name: wazuh-ca-issuer
+    kind: Issuer
+
+

--- a/overlays/certmanager/certmanager/issuer-selfsigned.yaml
+++ b/overlays/certmanager/certmanager/issuer-selfsigned.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-bootstrap
+  namespace: wazuh
+spec:
+  selfSigned: {}
+
+

--- a/overlays/certmanager/certmanager/issuer-wazuh-ca.yaml
+++ b/overlays/certmanager/certmanager/issuer-wazuh-ca.yaml
@@ -1,0 +1,10 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: wazuh-ca-issuer
+  namespace: wazuh
+spec:
+  ca:
+    secretName: wazuh-ca
+
+

--- a/overlays/certmanager/kustomization.yaml
+++ b/overlays/certmanager/kustomization.yaml
@@ -1,8 +1,23 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-bases:
-  - ../../wazuh
+namespace: wazuh
 
-# components:
-#   - ../../wazuh/certs
+resources:
+  - ../../wazuh/base
+  - ../../wazuh/secrets
+  - ../../wazuh/wazuh_managers
+  - ../../wazuh/indexer_stack
+  - certmanager/issuer-selfsigned.yaml
+  - certmanager/ca-certificate.yaml
+  - certmanager/issuer-wazuh-ca.yaml
+  - certmanager/certificates.yaml
+
+patches:
+  - path: patches/patch-dashboard-vol.yaml
+  - path: patches/patch-indexer-vol.yaml
+  - path: patches/patch-manager-master-vol.yaml
+  - path: patches/patch-manager-worker-vol.yaml
+
+
+  

--- a/overlays/certmanager/patches/patch-dashboard-vol.yaml
+++ b/overlays/certmanager/patches/patch-dashboard-vol.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wazuh-dashboard
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      volumes:
+        - name: dashboard-certs
+          secret: null
+          projected:
+            sources:
+              - secret:
+                  name: dashboard-certs
+                  items:
+                    - key: tls.crt
+                      path: cert.pem
+                    - key: tls.key
+                      path: key.pem
+                    - key: ca.crt
+                      path: root-ca.pem
+
+

--- a/overlays/certmanager/patches/patch-indexer-vol.yaml
+++ b/overlays/certmanager/patches/patch-indexer-vol.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-indexer
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      volumes:
+        - name: indexer-certs
+          secret: null
+          projected:
+            defaultMode: 0600
+            sources:
+              - secret:
+                  name: indexer-node
+                  items:
+                    - key: tls.crt
+                      path: node.pem
+                    - key: tls.key
+                      path: node-key.pem
+                    - key: ca.crt
+                      path: root-ca.pem
+              - secret:
+                  name: indexer-admin
+                  items:
+                    - key: tls.crt
+                      path: admin.pem
+                    - key: tls.key
+                      path: admin-key.pem
+        - name: indexer-conf
+          configMap:
+            name: indexer-conf
+            defaultMode: 0600
+
+

--- a/overlays/certmanager/patches/patch-manager-master-vol.yaml
+++ b/overlays/certmanager/patches/patch-manager-master-vol.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-manager-master
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      volumes:
+        - name: filebeat-certs
+          secret: null
+          projected:
+            defaultMode: 0600
+            sources:
+              - secret:
+                  name: filebeat-client
+                  items:
+                    - key: tls.crt
+                      path: filebeat.pem
+                    - key: tls.key
+                      path: filebeat-key.pem
+                    - key: ca.crt
+                      path: root-ca.pem
+      
+

--- a/overlays/certmanager/patches/patch-manager-worker-vol.yaml
+++ b/overlays/certmanager/patches/patch-manager-worker-vol.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: wazuh-manager-worker
+  namespace: wazuh
+spec:
+  template:
+    spec:
+      volumes:
+        - name: filebeat-certs
+          secret: null
+          projected:
+            sources:
+              - secret:
+                  name: filebeat-client
+                  items:
+                    - key: tls.crt
+                      path: filebeat.pem
+                    - key: tls.key
+                      path: filebeat-key.pem
+                    - key: ca.crt
+                      path: root-ca.pem

--- a/overlays/external-certs/kustomization.yaml
+++ b/overlays/external-certs/kustomization.yaml
@@ -1,8 +1,5 @@
-kind: Kustomization
-apiVersion: kustomize.config.k8s.io/v1beta1
-
-bases:
-  - ../../wazuh
-
-# components:
-#   - ../../wazuh/certs
+resources:
+  - ../../wazuh/base
+  - ../../wazuh/secrets
+  - ../../wazuh/wazuh_managers
+  - ../../wazuh/indexer_stack

--- a/overlays/local-certs/kustomization.yaml
+++ b/overlays/local-certs/kustomization.yaml
@@ -1,8 +1,11 @@
 kind: Kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 
-bases:
-  - ../../wazuh
+namespace: wazuh
 
-components:
+resources:
+  - ../../wazuh/base
+  - ../../wazuh/secrets
+  - ../../wazuh/wazuh_managers
   - ../../wazuh/certs
+  - ../../wazuh/indexer_stack

--- a/wazuh/base/kustomization.yaml
+++ b/wazuh/base/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - wazuh-ns.yaml
+  - storage-class.yaml

--- a/wazuh/certs/kustomization.yaml
+++ b/wazuh/certs/kustomization.yaml
@@ -1,7 +1,3 @@
-apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-
-# keep paths compatible with orignal setup
 secretGenerator:
   - name: indexer-certs
     files:

--- a/wazuh/indexer_stack/kustomization.yaml
+++ b/wazuh/indexer_stack/kustomization.yaml
@@ -1,0 +1,16 @@
+resources:
+  - wazuh-indexer/indexer-svc.yaml
+  - wazuh-indexer/cluster/indexer-api-svc.yaml
+  - wazuh-indexer/cluster/indexer-sts.yaml
+  - wazuh-dashboard/dashboard-svc.yaml
+  - wazuh-dashboard/dashboard-deploy.yaml
+
+configMapGenerator:
+  - name: indexer-conf
+    files:
+      - wazuh-indexer/indexer_conf/opensearch.yml
+      - wazuh-indexer/indexer_conf/internal_users.yml
+  
+  - name: dashboard-conf
+    files:
+      - wazuh-dashboard/dashboard_conf/opensearch_dashboards.yml

--- a/wazuh/kustomization.yml
+++ b/wazuh/kustomization.yml
@@ -5,44 +5,16 @@
 # License (version 2) as published by the FSF - Free Software
 # Foundation.
 
+# local-certs overlay should be used and this file should be removed
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 # Adds wazuh namespace to all resources.
 namespace: wazuh
 
-configMapGenerator:
-  - name: indexer-conf
-    files:
-      - indexer_stack/wazuh-indexer/indexer_conf/opensearch.yml
-      - indexer_stack/wazuh-indexer/indexer_conf/internal_users.yml
-  - name: wazuh-conf
-    files:
-      - wazuh_managers/wazuh_conf/master.conf
-      - wazuh_managers/wazuh_conf/worker.conf
-  - name: dashboard-conf
-    files:
-      - indexer_stack/wazuh-dashboard/dashboard_conf/opensearch_dashboards.yml
-
 resources:
-  - base/wazuh-ns.yaml
-  - base/storage-class.yaml
-
-  - secrets/wazuh-api-cred-secret.yaml
-  - secrets/wazuh-authd-pass-secret.yaml
-  - secrets/wazuh-cluster-key-secret.yaml
-  - secrets/dashboard-cred-secret.yaml
-  - secrets/indexer-cred-secret.yaml
-
-  - wazuh_managers/wazuh-cluster-svc.yaml
-  - wazuh_managers/wazuh-master-svc.yaml
-  - wazuh_managers/wazuh-workers-svc.yaml
-  - wazuh_managers/wazuh-master-sts.yaml
-  - wazuh_managers/wazuh-worker-sts.yaml
-
-  - indexer_stack/wazuh-indexer/indexer-svc.yaml
-  - indexer_stack/wazuh-indexer/cluster/indexer-api-svc.yaml
-  - indexer_stack/wazuh-indexer/cluster/indexer-sts.yaml
-
-  - indexer_stack/wazuh-dashboard/dashboard-svc.yaml
-  - indexer_stack/wazuh-dashboard/dashboard-deploy.yaml
+  - base
+  - secrets
+  - wazuh_managers
+  - certs
+  - indexer_stack

--- a/wazuh/secrets/kustomization.yaml
+++ b/wazuh/secrets/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+  - wazuh-api-cred-secret.yaml
+  - wazuh-authd-pass-secret.yaml
+  - wazuh-cluster-key-secret.yaml
+  - dashboard-cred-secret.yaml
+  - indexer-cred-secret.yaml

--- a/wazuh/wazuh_managers/kustomization.yaml
+++ b/wazuh/wazuh_managers/kustomization.yaml
@@ -1,0 +1,12 @@
+configMapGenerator:
+  - name: wazuh-conf
+    files:
+      - wazuh_conf/master.conf
+      - wazuh_conf/worker.conf
+
+resources:
+  - wazuh-master-svc.yaml
+  - wazuh-master-sts.yaml
+  - wazuh-workers-svc.yaml
+  - wazuh-worker-sts.yaml
+  - wazuh-cluster-svc.yaml


### PR DESCRIPTION
Changes in this PR

- new overlay to deploy wazuh using local generated certs
- new overlay to deploy wazuh using certmanager
- new overlay to deploy wazuh using external secrets
- each wazuh/<folder> is kustomization folder which can be used as component in overlay
- wazuh/kustomization.yaml should be deprecated and in the future overlay should be used

FIX:
- [#671](https://github.com/wazuh/wazuh-kubernetes/issues/671)