### PR TITLE
Forbid run local deployment test in draft PRs

### DIFF
--- a/.github/workflows/local-deployment-test.yml
+++ b/.github/workflows/local-deployment-test.yml
@@ -1,8 +1,9 @@
-run-name: Kubernetes Local deployment test - Branch ${{ inputs.BRANCH_VERSION }} - Launched by @${{ github.actor }}
+run-name: Kubernetes Local deployment test - Branch ${{ inputs.BRANCH_VERSION || github.head_ref }} - Launched by @${{ github.actor }}
 name: Test Wazuh Local deployment on Kubernetes
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
       BRANCH_VERSION:
@@ -23,12 +24,13 @@ env:
 
 jobs:
   Local_deployment_test:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.BRANCH_VERSION }}
+          ref: ${{ inputs.BRANCH_VERSION || github.head_ref }}
 
       - name: Configure aws credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Forbid run local deployment test in draft PRs ([#1459](https://github.com/wazuh/wazuh-kubernetes/pull/1459))
 - Change UID and GId for Wazuh deployment ([#1450](https://github.com/wazuh/wazuh-kubernetes/pull/1450))
 - Add certificates configuration script ([#1369](https://github.com/wazuh/wazuh-kubernetes/pull/1369))
 - Update artifact URLs file extension from .yml to .yaml ([#1363](https://github.com/wazuh/wazuh-kubernetes/pull/1363))


### PR DESCRIPTION
## Description

The goal of this PR is to prevent workflows from running on draft pull requests.

To achieve this, the necessary types have been added to the pull_request trigger, notably the ready_for_review type.

A condition has also been added to check whether the PR is in draft status, since the synchronized type in the pull_request trigger triggers whenever a commit is made to a PR, even if it is in draft status.

### Testing 🧪 

<details>
<summary>Draft PRs</summary>

<img width="869" height="335" alt="image" src="https://github.com/user-attachments/assets/5db734b9-b9d9-4b19-98e1-258e2368995c" />


</details>

<details>
<summary>Open PRs</summary>

<img width="851" height="433" alt="image" src="https://github.com/user-attachments/assets/1fab27fc-7da5-4f28-a550-4a9597b48f5b" />


</details>