### PR TITLE
Fix changelog check to accept Prior versions entries

### DIFF
--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -36,8 +36,12 @@ jobs:
             INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
-              echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'. Offending lines:"
+              echo "::error::Invalid CHANGELOG.md entries. Offending lines:"
               echo "$INVALID"
+              echo "::error::Expected formats:"
+              echo "::error::  - Change entry: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'"
+              echo "::error::  - Prior versions entry: '- [vX.Y.Z](https://github.com/<org>/<repo>/blob/vX.Y.Z/CHANGELOG.md)'"
+              echo "::error::  - Prior versions placeholder (no prior version): '- []()'"
             fi
           fi
 

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -31,15 +31,17 @@ jobs:
           else
             FORMAT="✅"
 
-            ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
+            TABLE_ENTRY_REGEX='^\| \[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\) \| .+ \|$'
+            TABLE_HEADER_REGEX='^\| Issue \| Comment \|$|^\| - \| - \|$'
             PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
+            INVALID=$(echo "$ADDED" | grep -E '^(\||-)' | grep -vx -- '- None' | grep -vE "$TABLE_HEADER_REGEX" | grep -vE "$TABLE_ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
+
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
               echo "::error::Invalid CHANGELOG.md entries. Offending lines:"
               echo "$INVALID"
               echo "::error::Expected formats:"
-              echo "::error::  - Change entry: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'"
+              echo "::error::  - Table entry: '| [#123](https://github.com/<org>/<repo>/issues/123) | Description |'"
               echo "::error::  - Prior versions entry: '- [vX.Y.Z](https://github.com/<org>/<repo>/blob/vX.Y.Z/CHANGELOG.md)'"
               echo "::error::  - Prior versions placeholder (no prior version): '- []()'"
             fi

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -32,7 +32,8 @@ jobs:
             FORMAT="✅"
 
             ENTRY_REGEX='^- .+ \(\[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\)\)$'
-            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" || true)
+            PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'
+            INVALID=$(echo "$ADDED" | grep -E '^- ' | grep -vx -- '- None' | grep -vE "$ENTRY_REGEX" | grep -vE "$PRIOR_VERSION_REGEX" || true)
             if [ -n "$INVALID" ]; then
               FORMAT="❌"
               echo "::error::Invalid CHANGELOG.md entries. Expected format: '- Description ([#123](https://github.com/<org>/<repo>/issues/123))'. Offending lines:"

--- a/.github/workflows/5_changelog_check.yml
+++ b/.github/workflows/5_changelog_check.yml
@@ -30,7 +30,6 @@ jobs:
             echo "::error::CHANGELOG.md was not updated with new entries. Add one or add the 'no-changelog' label to skip this check."
           else
             FORMAT="✅"
-
             TABLE_ENTRY_REGEX='^\| \[#[0-9]+\]\(https://github\.com/[^)]+/(issues|pull)/[0-9]+\) \| .+ \|$'
             TABLE_HEADER_REGEX='^\| Issue \| Comment \|$|^\| - \| - \|$'
             PRIOR_VERSION_REGEX='^- \[v?[0-9]+\.[0-9]+\.[0-9]+\]\(https://github\.com/[^)]+/blob/[^)]+/CHANGELOG\.md\)$|^- \[\]\(\)$'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,12 +50,13 @@
 
 | Issue | Comment |
 | - | - |
+| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
 | [#1563](https://github.com/wazuh/wazuh-kubernetes/pull/1563) | Fix bumper workflow failure when bump produces no changes |
 | [#1526](https://github.com/wazuh/wazuh-kubernetes/issues/1526) | Bumper script issue when the tag is set to false |
 | [#1467](https://github.com/wazuh/wazuh-kubernetes/issues/1467) | Errors on bumper execution |
 | [#1449](https://github.com/wazuh/wazuh-kubernetes/issues/1449) | Change API password to default |
 | [#1340](https://github.com/wazuh/wazuh-kubernetes/issues/1340) | Fix test for deployment |
-| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
+
 
 ## Prior version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 | [#1467](https://github.com/wazuh/wazuh-kubernetes/issues/1467) | Errors on bumper execution |
 | [#1449](https://github.com/wazuh/wazuh-kubernetes/issues/1449) | Change API password to default |
 | [#1340](https://github.com/wazuh/wazuh-kubernetes/issues/1340) | Fix test for deployment |
+| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
 
 ## Prior version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 | Issue | Comment |
 | - | - |
-| [#3657](https://github.com/wazuh/wazuh-automation/issues/3657) | Fix changelog check to accept Prior versions entries |
+| [#1595](https://github.com/wazuh/wazuh-kubernetes/pull/1595) | Fix changelog check to accept Prior versions entries |
 | [#1563](https://github.com/wazuh/wazuh-kubernetes/pull/1563) | Fix bumper workflow failure when bump produces no changes |
 | [#1526](https://github.com/wazuh/wazuh-kubernetes/issues/1526) | Bumper script issue when the tag is set to false |
 | [#1467](https://github.com/wazuh/wazuh-kubernetes/issues/1467) | Errors on bumper execution |


### PR DESCRIPTION
## Changes
- Added a `PRIOR_VERSION_REGEX` pattern recognizing version changelog
  links and the empty placeholder `- []()`
- Standard PR/Issue entries continue to validate as before

## Tests
Verified with test PRs (not to be merged):

- Standard entry (valid): https://github.com/wazuh/wazuh-kubernetes/pull/1596 → **passed**
- Prior versions entry (valid): https://github.com/wazuh/wazuh-kubernetes/pull/1597 → **passed**
- Both sections combined (valid): https://github.com/wazuh/wazuh-kubernetes/pull/1598 → **passed**
- Invalid format entry: https://github.com/wazuh/wazuh-kubernetes/pull/1599 → **failed**
- Another invalid format entry: https://github.com/wazuh/wazuh-kubernetes/pull/1600 → **failed**

## Related issue
https://github.com/wazuh/wazuh-automation/issues/3657