### PR TITLE
[TEST - DO NOT MERGE] Validate changelog_check correctly rejects invalid entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 | Issue | Comment |
 | - | - |
+| This is not a valid entry format | Missing issue link |
 | [#1595](https://github.com/wazuh/wazuh-kubernetes/pull/1595) | Fix changelog check to accept Prior versions entries |
 | [#1563](https://github.com/wazuh/wazuh-kubernetes/pull/1563) | Fix bumper workflow failure when bump produces no changes |
 | [#1526](https://github.com/wazuh/wazuh-kubernetes/issues/1526) | Bumper script issue when the tag is set to false |
@@ -60,4 +61,4 @@
 
 ## Prior version
 
-- []()
+- [](


### PR DESCRIPTION
## Purpose
Test PR to confirm that, after the changelog_check fix, the workflow still correctly **fails** on malformed entries

## Related pull request
#1595
