### PR TITLE
Remove unused deployability/deps install in k8s integration tests

### DIFF
--- a/.github/workflows/5_check_k8s_integration_tests.yaml
+++ b/.github/workflows/5_check_k8s_integration_tests.yaml
@@ -283,7 +283,6 @@ jobs:
 
       - name: Install test_runner
         run: |
-          pip install -r wazuh-automation/deployability/deps/requirements.txt
           pip install -r wazuh-automation/integration-test-module/requirements.txt
           pip install -e wazuh-automation/integration-test-module/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 | Issue | Comment |
 | - | - |
+| [#1611](https://github.com/wazuh/wazuh-kubernetes/pull/1611) | Remove unused deployability/deps install in k8s integration tests |
 | [#1608](https://github.com/wazuh/wazuh-kubernetes/issues/1608) | Change Codebuild runners to Github runners. |
 | [#1567](https://github.com/wazuh/wazuh-kubernetes/issues/1567) | Update deployment for Wazuh Indexer 5.0.0 RBAC. |
 | [#1569](https://github.com/wazuh/wazuh-kubernetes/pull/1569) | Add new WF for changelog check |


### PR DESCRIPTION
Drops the unused Allocator `requirements.txt` install from this workflow — `integration-test-module` already declares the same dependencies on its own, and this pipeline never calls the Allocator. No replacement is needed since it isn't used here.

## Related to 
https://github.com/wazuh/internal-devel-requests/issues/5888